### PR TITLE
Updating repository ref to OCI endpoint of chart-library

### DIFF
--- a/servicebus/Chart.yaml
+++ b/servicebus/Chart.yaml
@@ -20,4 +20,4 @@ keywords:
 dependencies:
   - name: library
     version: 2.2.2
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    repository: oci://hmctspublic.azurecr.io/helm


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-23130

### Change description ###
Updating Chart library reference to point at the new OCI endpoint as part of the upgrade work for DTSPO-23130.
All base charts will need an update as part of this work.

The new release off the back of this PR will also move chart-servicebus to the OCI endpoint.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
